### PR TITLE
Use can-ajax rather than can-util/dom/ajax/

### DIFF
--- a/can-todomvc-test.js
+++ b/can-todomvc-test.js
@@ -2,7 +2,7 @@ var QUnit = require("steal-qunit");
 QUnit.config.reorder = false;
 require("./todomvc.css");
 var domDispatch = require("can-util/dom/dispatch/");
-var ajax = require("can-util/dom/ajax/");
+var ajax = require("can-ajax");
 
 function waitFor(test){
     return new Promise(function(resolve){

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   "author": "",
   "license": "MIT",
   "dependencies": {
+    "can-ajax": "^1.1.4",
     "can-util": "^3.3.2",
     "steal-css": "^1.2.1",
     "steal-qunit": "^1.0.1"


### PR DESCRIPTION
Prevents an unneeded warning.