### PR TITLE
Use can-ajax instead of can-util/dom/ajax/

### DIFF
--- a/can-todomvc-test.js
+++ b/can-todomvc-test.js
@@ -2,7 +2,7 @@ var QUnit = require("steal-qunit");
 QUnit.config.reorder = false;
 require("./todomvc.css");
 var domDispatch = require("can-util/dom/dispatch/");
-var ajax = require("can-util/dom/ajax/");
+var ajax = require("can-ajax");
 var canSymbol = require("can-symbol");
 
 function waitFor(test){


### PR DESCRIPTION
@matthewp I just noticed that you reverted the change to use `can-ajax` in https://github.com/canjs/can-todomvc-test/pull/5/files; what was the issue you ran into?